### PR TITLE
ETH Token Decimal Display Changed to 5 Digits

### DIFF
--- a/src/components/ssSwap/setup.jsx
+++ b/src/components/ssSwap/setup.jsx
@@ -2,7 +2,7 @@ import React, { Fragment, useState, useEffect } from 'react'
 
 import { withTheme } from '@material-ui/core/styles'
 
-import { formatCurrency, formatAddress } from '../../utils'
+import { formatCurrency, formatAddress, formatTokenBalance } from '../../utils'
 
 import stores from '../../stores'
 import { ACTIONS, ETHERSCAN_URL, TOP_ASSETS, CONTRACTS } from '../../stores/constants'
@@ -852,10 +852,12 @@ function Setup() {
             <div className="flex items-center">
               <span>
                 {isFromPerToRate
-                  ? `1 ${fromAssetValue?.symbol} = ${formatCurrency(
+                  ? `1 ${fromAssetValue?.symbol} = ${formatTokenBalance(
+                      toAssetValue?.symbol,
                       BigNumber(quote.output.finalValue).div(quote.inputs.fromAmount).toFixed(18)
                     )} ${toAssetValue?.symbol}`
-                  : `1 ${toAssetValue?.symbol} = ${formatCurrency(
+                  : `1 ${toAssetValue?.symbol} = ${formatTokenBalance(
+                      fromAssetValue?.symbol,
                       BigNumber(quote.inputs.fromAmount).div(quote.output.finalValue).toFixed(18)
                     )} ${fromAssetValue?.symbol}`}
               </span>
@@ -886,7 +888,8 @@ function Setup() {
               </span>
             </div>
             <div className="flex items-center">
-              {`${formatCurrency(
+              {`${formatTokenBalance(
+                toAssetValue?.symbol,
                 BigNumber(quote.output.finalValue)
                   .times(1 - slippage / 100)
                   .toFixed(18)
@@ -1112,7 +1115,9 @@ function Setup() {
                 }}
               >
                 <span className="text-text-gray">{'Balance:'}</span>
-                <span className="font-semibold text-text-gray">{' ' + formatCurrency(assetValue.balance)}</span>
+                <span className="font-semibold text-text-gray">
+                  {' ' + formatTokenBalance(assetValue.symbol, assetValue.balance)}
+                </span>
               </div>
             )}
           </div>

--- a/src/stores/constants/index.js
+++ b/src/stores/constants/index.js
@@ -17,3 +17,10 @@ export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 export const FALLBACK_RPC = process.env.NEXT_PUBLIC_CHAIN_RPC
 
 export const TOP_ASSETS = ['WETH', 'TAIKO', 'KODO', 'USDC', 'USDC.e', 'LRC']
+
+export const TOKEN_DISPLAY_DECIMALS = {
+  ETH: 5,
+  WETH: 5,
+  rETH: 5,
+  wstETH: 5,
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { TOKEN_DISPLAY_DECIMALS } from '../stores/constants/index.js'
 
 /**
  * Formats a number as a currency string.
@@ -20,6 +21,10 @@ export function formatCurrency(amount, decimals = 2, largeNumberFormat = false) 
       return '< 0.0001'
     }
 
+    if (decimals === 5 && bnAmount.gt(0) && bnAmount.lt(0.00001)) {
+      return '< 0.00001'
+    }
+
     if (largeNumberFormat) {
       if (bnAmount.gte(1e9)) {
         return bnAmount.div(1e9).toFixed(decimals) + 'B'
@@ -39,6 +44,14 @@ export function formatCurrency(amount, decimals = 2, largeNumberFormat = false) 
   } else {
     return 0
   }
+}
+
+export function formatTokenBalance(token, balance) {
+  const decimals = TOKEN_DISPLAY_DECIMALS[token]
+  if (decimals !== undefined) {
+    return formatCurrency(balance, decimals)
+  }
+  return formatCurrency(balance)
 }
 
 export function formatAddress(address, length = 'short') {


### PR DESCRIPTION
Update the Swap Page: The decimal places displayed for ETH tokens have been changed to 5 digits.