### PR TITLE
update: ETH Token Decimal Display Changed to 5 Digits 

### DIFF
--- a/src/components/ssBribes/ssBribeCreate.jsx
+++ b/src/components/ssBribes/ssBribeCreate.jsx
@@ -2,7 +2,7 @@ import { Fragment, useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { Typography } from '@material-ui/core'
 import BigNumber from 'bignumber.js'
-import { formatCurrency } from '../../utils'
+import { formatCurrency, formatTokenBalance } from '../../utils'
 import classes from './ssBribeCreate.module.css'
 
 import stores from '../../stores'
@@ -185,7 +185,9 @@ export default function BribeCreate() {
             <span className="text-text-gray">Bribe token</span>
           </div>
           <span className="text-text-gray">
-            {`Wallet: ${assetValue?.balance ? formatCurrency(assetValue.balance) : formatCurrency(0)}`}
+            {`Wallet: ${
+              assetValue?.balance ? formatTokenBalance(assetValue.symbol, assetValue.balance) : formatCurrency(0)
+            }`}
           </span>
         </div>
         <div className="overflow-hidden rounded-[10px] bg-table-dark border border-border pr-4 focus-within:border-pink-primary hover:border-pink-primary transition-colors duration-300">

--- a/src/components/ssBribes/ssBribesTable.jsx
+++ b/src/components/ssBribes/ssBribesTable.jsx
@@ -17,7 +17,7 @@ import {
 import { useRouter } from 'next/router'
 import FilterListIcon from '@material-ui/icons/FilterList'
 import SearchIcon from '@material-ui/icons/Search'
-import { formatCurrency, formatAddress } from '../../utils'
+import { formatCurrency, formatAddress, formatTokenBalance } from '../../utils'
 import BigNumber from 'bignumber.js'
 import Image from 'next/image'
 import { ETHERSCAN_URL, CONTRACTS } from '../../stores/constants'
@@ -600,7 +600,7 @@ export default function EnhancedTable({ gauges }) {
                             key={idx}
                             className="flex flex-row gap-[4px] items-center justify-end text-white text-sm leading-[18px] font-medium"
                           >
-                            <div className="">{formatCurrency(bribe.rewardAmount)}</div>
+                            <div className="">{formatTokenBalance(bribe.token.symbol, bribe.rewardAmount)}</div>
                             <div className="">{bribe.token.symbol}</div>
                             <img
                               className="aspect-square rounded-full"

--- a/src/components/ssLiquidityCreate/index.jsx
+++ b/src/components/ssLiquidityCreate/index.jsx
@@ -2,7 +2,7 @@ import { Fragment, useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 // import { Typography, MenuItem, Select } from '@material-ui/core'
 import BigNumber from 'bignumber.js'
-import { formatCurrency, formatAddress } from '../../utils'
+import { formatCurrency, formatAddress, formatTokenBalance } from '../../utils'
 // import classes from './ssLiquidityCreate.module.css'
 
 import stores from '../../stores'
@@ -259,7 +259,7 @@ function AssetSelect({ type, value, assetOptions, onSelect }) {
           </div>
           <div className="flex flex-col gap-1 text-right text-xs sm:text-sm">
             <div className="ml-auto">
-              <p>{asset && asset.balance ? formatCurrency(asset.balance) : '0.00'}</p>
+              <p>{asset && asset.balance ? formatTokenBalance(asset.symbol, asset.balance) : '0.00'}</p>
               <p className="text-[10px] sm:text-sm text-text-gray">Balance</p>
             </div>
           </div>

--- a/src/components/ssLiquidityManage/index.jsx
+++ b/src/components/ssLiquidityManage/index.jsx
@@ -1882,7 +1882,7 @@ export default function LiquidityManage() {
                               alt=""
                               width="24"
                               height="24"
-                              className="mr-1 h-[24px] w-[24px]"
+                              className="mr-1 h-[24px] w-[24px] rounded-full"
                               src={pair?.token0?.logoURI}
                               onError={(e) => {
                                 e.target.onerror = null
@@ -1919,7 +1919,7 @@ export default function LiquidityManage() {
                                 alt=""
                                 width="24"
                                 height="24"
-                                className="mr-1 h-[24px] w-[24px]"
+                                className="mr-1 h-[24px] w-[24px] rounded-full"
                                 src={pair?.token1?.logoURI}
                                 onError={(e) => {
                                   e.target.onerror = null

--- a/src/components/ssLiquidityPairs/ssLiquidityPairsTable.jsx
+++ b/src/components/ssLiquidityPairs/ssLiquidityPairsTable.jsx
@@ -13,7 +13,7 @@ import {
   InformationCircleIcon as InformationCircleIconSolid,
 } from '@heroicons/react/24/solid'
 import { InformationCircleIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
-import { formatCurrency, formatAddress } from '../../utils'
+import { formatCurrency, formatAddress, formatTokenBalance } from '../../utils'
 import { ETHERSCAN_URL, CONTRACTS } from '../../stores/constants'
 
 import { Tooltip } from 'react-tooltip'
@@ -925,7 +925,10 @@ export default function EnhancedTable({ pairs, account }) {
                                 <div className="flex flex-row gap-1 justify-end text-text-gray text-[10px] leading-[13px] font-normal mb-[2px]">
                                   <div className="">
                                     {row?.balance && row?.totalSupply && row?.reserve0
-                                      ? formatCurrency(BigNumber(row.balance).div(row.totalSupply).times(row.reserve0))
+                                      ? formatTokenBalance(
+                                          row?.token0?.symbol,
+                                          BigNumber(row.balance).div(row.totalSupply).times(row.reserve0)
+                                        )
                                       : '0.00'}
                                   </div>
                                   <div className="">{row?.token0?.symbol ?? ''}</div>
@@ -933,7 +936,10 @@ export default function EnhancedTable({ pairs, account }) {
                                 <div className="flex flex-row gap-1 justify-end text-text-gray text-[10px] leading-[13px] font-normal mb-[2px]">
                                   <div className="">
                                     {row?.balance && row?.totalSupply && row?.reserve1
-                                      ? formatCurrency(BigNumber(row.balance).div(row.totalSupply).times(row.reserve1))
+                                      ? formatTokenBalance(
+                                          row?.token1?.symbol,
+                                          BigNumber(row.balance).div(row.totalSupply).times(row.reserve1)
+                                        )
                                       : '0.00'}
                                   </div>
                                   <div className="">{row?.token1?.symbol ?? ''}</div>
@@ -957,7 +963,8 @@ export default function EnhancedTable({ pairs, account }) {
                                 <div className="flex flex-row gap-1 justify-end text-text-gray text-[10px] leading-[13px] font-normal mb-[2px]">
                                   <div className="">
                                     {row?.gauge?.balance && row?.gauge?.totalSupply && row?.gauge?.reserve0
-                                      ? formatCurrency(
+                                      ? formatTokenBalance(
+                                          row?.token0?.symbol,
                                           BigNumber(row.gauge.balance)
                                             .div(row.gauge.totalSupply)
                                             .times(row.gauge.reserve0)
@@ -969,7 +976,8 @@ export default function EnhancedTable({ pairs, account }) {
                                 <div className="flex flex-row gap-1 justify-end text-text-gray text-[10px] leading-[13px] font-normal mb-[2px]">
                                   <div className="">
                                     {row?.gauge?.balance && row?.gauge?.totalSupply && row?.gauge?.reserve1
-                                      ? formatCurrency(
+                                      ? formatTokenBalance(
+                                          row?.token1?.symbol,
                                           BigNumber(row.gauge.balance)
                                             .div(row.gauge.totalSupply)
                                             .times(row.gauge.reserve1)

--- a/src/components/ssRewards/ssRewardsTable.jsx
+++ b/src/components/ssRewards/ssRewardsTable.jsx
@@ -5,7 +5,7 @@ import React from 'react'
 // import { useRouter } from 'next/router'
 import BigNumber from 'bignumber.js'
 
-import { formatCurrency } from '../../utils'
+import { formatCurrency, formatTokenBalance } from '../../utils'
 import stores from '../../stores'
 import { ACTIONS } from '../../stores/constants'
 // import Image from 'next/image'
@@ -380,7 +380,11 @@ export default function EnhancedTable({ rewards, tokenID }) {
                       <div className="flex flex-col gap-1">
                         <div className="flex flex-row gap-1 justify-end items-center text-white text-sm leading-[18px] font-medium">
                           <div className="">
-                            {formatCurrency(BigNumber(row.balance).div(row.totalSupply).times(row.reserve0))}
+                            {/* {formatCurrency(BigNumber(row.balance).div(row.totalSupply).times(row.reserve0))} */}
+                            {formatTokenBalance(
+                              row.token0.symbol,
+                              BigNumber(row.balance).div(row.totalSupply).times(row.reserve0)
+                            )}
                           </div>
                           <div className="">{row.token0.symbol}</div>
                           <img
@@ -397,7 +401,11 @@ export default function EnhancedTable({ rewards, tokenID }) {
                         </div>
                         <div className="flex flex-row gap-1 justify-end items-center text-white text-sm leading-[18px] font-medium">
                           <div className="">
-                            {formatCurrency(BigNumber(row.balance).div(row.totalSupply).times(row.reserve1))}
+                            {/* {formatCurrency(BigNumber(row.balance).div(row.totalSupply).times(row.reserve1))} */}
+                            {formatTokenBalance(
+                              row.token1.symbol,
+                              BigNumber(row.balance).div(row.totalSupply).times(row.reserve1)
+                            )}
                           </div>
                           <div className="">{row.token1.symbol}</div>
                           <img
@@ -418,7 +426,11 @@ export default function EnhancedTable({ rewards, tokenID }) {
                       <div className="flex flex-col gap-1">
                         <div className="flex flex-row gap-1 items-center justify-end text-white text-sm leading-[18px] font-medium">
                           <div className="">
-                            {formatCurrency(
+                            {/* {formatCurrency(
+                              BigNumber(row.gauge.balance).div(row.gauge.totalSupply).times(row.gauge.reserve0)
+                            )} */}
+                            {formatTokenBalance(
+                              row.token0.symbol,
                               BigNumber(row.gauge.balance).div(row.gauge.totalSupply).times(row.gauge.reserve0)
                             )}
                           </div>
@@ -437,7 +449,11 @@ export default function EnhancedTable({ rewards, tokenID }) {
                         </div>
                         <div className="flex flex-row gap-1 items-center justify-end text-white text-sm leading-[18px] font-medium">
                           <div className="">
-                            {formatCurrency(
+                            {/* {formatCurrency(
+                              BigNumber(row.gauge.balance).div(row.gauge.totalSupply).times(row.gauge.reserve1)
+                            )} */}
+                            {formatTokenBalance(
+                              row.token1.symbol,
                               BigNumber(row.gauge.balance).div(row.gauge.totalSupply).times(row.gauge.reserve1)
                             )}
                           </div>
@@ -490,7 +506,7 @@ export default function EnhancedTable({ rewards, tokenID }) {
                       {row && row.rewardType === 'Fees' && (
                         <div className="flex flex-col gap-1">
                           <div className="flex flex-row gap-[4px] items-center justify-end text-white text-sm leading-[18px] font-medium">
-                            <div className="">{formatCurrency(row.claimable0)}</div>
+                            <div className="">{formatTokenBalance(row.token0?.symbol, row.claimable0)}</div>
                             <div className="">{row.token0?.symbol}</div>
                             <img
                               className="aspect-square rounded-full w-[14px] h-[14px]"
@@ -516,7 +532,7 @@ export default function EnhancedTable({ rewards, tokenID }) {
                             /> */}
                           </div>
                           <div className="flex flex-row gap-[4px] items-center justify-end text-white text-sm leading-[18px] font-medium">
-                            <div className="">{formatCurrency(row.claimable1)}</div>
+                            <div className="">{formatTokenBalance(row.token1?.symbol, row.claimable1)}</div>
                             <div className="">{row.token1?.symbol}</div>
                             <img
                               className="aspect-square rounded-full w-[14px] h-[14px]"
@@ -584,7 +600,7 @@ export default function EnhancedTable({ rewards, tokenID }) {
                     {row && row.rewardType === 'Fees' && (
                       <div className="flex flex-col gap-1">
                         <div className="flex flex-row gap-[4px] items-center justify-end text-white text-sm leading-[18px] font-medium">
-                          <div className="">{formatCurrency(row.claimable0)}</div>
+                          <div className="">{formatTokenBalance(row.token0?.symbol, row.claimable0)}</div>
                           <div className="">{row.token0?.symbol}</div>
                           <img
                             className="aspect-square rounded-full w-[14px] h-[14px]"
@@ -610,7 +626,7 @@ export default function EnhancedTable({ rewards, tokenID }) {
                           /> */}
                         </div>
                         <div className="flex flex-row gap-[4px] items-center justify-end text-white text-sm leading-[18px] font-medium">
-                          <div className="">{formatCurrency(row.claimable1)}</div>
+                          <div className="">{formatTokenBalance(row.token1?.symbol, row.claimable1)}</div>
                           <div className="">{row.token1?.symbol}</div>
                           <img
                             className="aspect-square rounded-full w-[14px] h-[14px]"

--- a/src/components/ssRewards/ssRewardsTableForVe.jsx
+++ b/src/components/ssRewards/ssRewardsTableForVe.jsx
@@ -5,7 +5,7 @@ import React from 'react'
 // import { useRouter } from 'next/router'
 import BigNumber from 'bignumber.js'
 
-import { formatCurrency } from '../../utils'
+import { formatCurrency, formatTokenBalance } from '../../utils'
 import stores from '../../stores'
 import { ACTIONS } from '../../stores/constants'
 // import Image from 'next/image'
@@ -449,7 +449,7 @@ export default function EnhancedTable({ rewards, tokenID }) {
                               key={index}
                               className="flex flex-row gap-[4px] items-center justify-end text-white text-sm leading-[18px] font-medium"
                             >
-                              <div className="">{formatCurrency(bribe.earned)}</div>
+                              <div className="">{formatTokenBalance(bribe.token?.symbol, bribe.earned)}</div>
                               <div className="">{bribe.token?.symbol}</div>
                               <img
                                 className="rounded-full w-[14px] h-[14px]"

--- a/src/components/ssSwap/setup.jsx
+++ b/src/components/ssSwap/setup.jsx
@@ -288,7 +288,7 @@ function AssetSelect({ type, value, assetOptions, onSelect }) {
           </div>
           <div className="flex flex-col gap-1 text-right text-xs sm:text-sm">
             <div className="ml-auto">
-              <p>{asset && asset.balance ? formatCurrency(asset.balance) : '0.00'}</p>
+              <p>{asset && asset.balance ? formatTokenBalance(asset.symbol, asset.balance) : '0.00'}</p>
               <p className="text-[10px] sm:text-sm text-text-gray">Balance</p>
             </div>
           </div>

--- a/src/components/ssVests/vestNFT.jsx
+++ b/src/components/ssVests/vestNFT.jsx
@@ -198,7 +198,7 @@ export default function VestNFT({ nft, govToken, baseAssets }) {
             </div>
           </div>
           <div className="flex flex-col text-sm gap-[6px] bg-table-dark border border-border p-4 rounded-xl mt-4">
-            <div className="text-text-gray text-xs">Locked KODO Value</div>
+            <div className="text-text-gray text-xs">Locked KODO Value ≈</div>
             <div className="flex flex-row justify-between items-center">
               <div className="flex flex-row items-center gap-[6px]">
                 <img

--- a/src/components/ssVests/vestNFT.jsx
+++ b/src/components/ssVests/vestNFT.jsx
@@ -227,7 +227,7 @@ export default function VestNFT({ nft, govToken, baseAssets }) {
                 />
                 <div className="text-text-gray text-xs">ETH</div>
               </div>
-              <div className="text-white text-xs">{`${calculateEthTokenValue(nft)}`}</div>
+              <div className="text-white text-xs">{`Ξ${calculateEthTokenValue(nft)}`}</div>
             </div>
           </div>
           <div className="flex flex-row justify-between gap-4 mt-[9px]">

--- a/src/components/ssVotes/ssVotesTable.jsx
+++ b/src/components/ssVotes/ssVotesTable.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import BigNumber from 'bignumber.js'
 
-import { formatCurrency, formatAddress } from '../../utils'
+import { formatCurrency, formatAddress, formatTokenBalance } from '../../utils'
 
 import { MagnifyingGlassIcon, ArrowDownIcon, ArrowUpIcon } from '@heroicons/react/24/solid'
 import { InformationCircleIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
@@ -705,7 +705,9 @@ export default function EnhancedTable({ gauges, setParentSliderValues, defaultVo
                                     return (
                                       <div key={idx} className="flex flex-col gap-1">
                                         <div className="flex flex-row gap-[4px] items-center justify-end text-white text-sm leading-[18px] font-medium">
-                                          <div className="">{formatCurrency(bribe.rewardAmount)}</div>
+                                          <div className="">
+                                            {formatTokenBalance(bribe.token.symbol, bribe.rewardAmount)}
+                                          </div>
                                           <div className="">{bribe.token.symbol}</div>
                                           <img
                                             className="aspect-square rounded-full"

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -47,8 +47,14 @@ export function formatCurrency(amount, decimals = 2, largeNumberFormat = false) 
 }
 
 export function formatTokenBalance(token, balance) {
+  const bnAmount = BigNumber(balance)
+
+  if (bnAmount.isNaN()) {
+    return '0.00'
+  }
+
   const decimals = TOKEN_DISPLAY_DECIMALS[token]
-  if (decimals !== undefined) {
+  if (decimals !== undefined && bnAmount.gt(0)) {
     return formatCurrency(balance, decimals)
   }
   return formatCurrency(balance)


### PR DESCRIPTION
Changed ETH token decimal display to 5 digits. Some new updates:

1. Updated the asset selection popup, liquidity page, vote page, bribe page, and reward page.
2. Updated to display 0.00 even if the asset balance is 0.
3. Minor changes to the lock page.